### PR TITLE
Gemfile modification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem "culerity"
   gem "cucumber"
-  gem "capybara", "~> 1"
+  gem "capybara"
   #gem "faye-websocket"
   gem "poltergeist"
   gem "database_cleaner"


### PR DESCRIPTION
Fix #1. Remove version specification for gem capybara to avoid from different version from the top Gemfile.